### PR TITLE
Resolve Issue #5 from sub-module dependency fix in vue-chartjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 npm-debug.log
 .idea/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "vee-validate": "2.0.0-rc.7",
     "vue": "^2.3.0",
     "vue-bulma-expanding": "0.0.0",
-    "vue-chartjs": "^2.7.1",
+    "vue-chartjs": "^2.8.1",
     "vue-router": "^2.2.0",
     "vue-slider-component": "^2.3.3",
     "vue2-circle-progress": "^1.0.3",


### PR DESCRIPTION
I've tested locally and the fix provided by @apertureless appears to have resolved the issue of charts being oversized by 2X in the latest release [2.8.1](https://github.com/apertureless/vue-chartjs/tree/v2.8.1) of [vue-chartjs](https://github.com/apertureless/vue-chartjs) from the related issue I reported on that library.