### PR TITLE
fix: remove unused navbar toggle

### DIFF
--- a/src/components/layout/navbar/Navbar.vue
+++ b/src/components/layout/navbar/Navbar.vue
@@ -7,11 +7,6 @@
     </div>
 
     <div class="row navbar-container">
-      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
-              data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false"
-              aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
 
       <div class="menu-icon-container d-flex align-items-center justify-content-center justify-content-lg-start col">
         <a class="menu-icon i-menu-expanded" href="#" @click.prevent="toggleSidebar(false)" v-if="sidebarOpened"></a>


### PR DESCRIPTION
Removing this button, since it seems unused, but does show its outline when you focus.

<img width="654" alt="screen shot 2017-10-10 at 23 53 36" src="https://user-images.githubusercontent.com/3808818/31519900-4f35788e-afa4-11e7-988c-d09fb0946308.png">