### PR TITLE
Add support to provide objects to the selectors

### DIFF
--- a/src/components/forms/form-elements/FormElements.vue
+++ b/src/components/forms/form-elements/FormElements.vue
@@ -127,6 +127,7 @@
                   <vuestic-simple-select
                     label="Simple select"
                     v-model="simpleSelectModel"
+                    option-key="description"
                     v-bind:options="simpleOptions">
                   </vuestic-simple-select>
                   <vuestic-simple-select
@@ -141,6 +142,7 @@
                   <vuestic-multi-select
                     label="Mutliselect"
                     v-model="multiSelectModel"
+                    option-key="description"
                     v-bind:options="simpleOptions">
                   </vuestic-multi-select>
                   <vuestic-multi-select
@@ -299,7 +301,20 @@
         clearableText: '',
         successfulEmail: 'andrei@dreamsupport.io',
         wrongEmail: 'andrei@dreamsupport',
-        simpleOptions: ['First option', 'Second option', 'Third option'],
+        simpleOptions: [
+          {
+            id: 1,
+            description: 'First option'
+          },
+          {
+            id: 2,
+            description: 'Second option'
+          },
+          {
+            id: 3,
+            description: 'Third option'
+          }
+        ],
         simpleSelectModel: '',
         multiSelectModel: [],
         multiSelectCountriesModel: []

--- a/src/components/vuestic-components/vuestic-multi-select/VuesticMultiSelect.vue
+++ b/src/components/vuestic-components/vuestic-multi-select/VuesticMultiSelect.vue
@@ -18,7 +18,7 @@
           <div class="dropdown-item"
                :class="{'selected': isOptionSelected(option)}" v-for="option in options"
                @click="toggleSelection(option)">
-            <span class="ellipsis">{{option}}</span>
+            <span class="ellipsis">{{optionKey ? option[optionKey] : option}}</span>
             <i class="fa fa-check selected-icon"></i>
           </div>
         </div>
@@ -49,6 +49,7 @@
       label: String,
       options: Array,
       value: Array,
+      optionKey: String,
       required: {
         type: Boolean,
         default: false
@@ -80,7 +81,7 @@
         if (newVal.length > 2) {
           this.displayValue = `${newVal.length} of ${this.options.length} chosen`
         } else {
-          this.displayValue = newVal.join(', ')
+          this.displayValue = (this.optionKey ? newVal.map(item => item[this.optionKey]) : newVal).join(', ')
         }
       },
       validate () {

--- a/src/components/vuestic-components/vuestic-simple-select/VuesticSimpleSelect.vue
+++ b/src/components/vuestic-components/vuestic-simple-select/VuesticSimpleSelect.vue
@@ -19,7 +19,7 @@
           <div class="dropdown-item"
                :class="{'selected': isOptionSelected(option)}" v-for="option in options"
                @click="selectOption(option)">
-            <span class="ellipsis">{{option}}</span>
+            <span class="ellipsis">{{optionKey ? option[optionKey] : option}}</span>
           </div>
         </div>
       </scrollbar>
@@ -49,6 +49,7 @@
       label: String,
       options: Array,
       value: {},
+      optionKey: String,
       required: {
         type: Boolean,
         default: false
@@ -71,7 +72,7 @@
         this.$emit('input', option)
       },
       updateDisplayValue (val) {
-        this.displayValue = val
+        this.displayValue = this.optionKey ? val[this.optionKey] : val
       },
       validate () {
         this.validated = true


### PR DESCRIPTION
With this changes, you can provide objects to `vuestic-simple-select` and `vuestic-multi-select` specifying which object key (eg: `option-key="description"`) has the string to show in the selector.