### PR TITLE
update node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "friendly-errors-webpack-plugin": "1.6.1",
     "html-webpack-plugin": "2.30.1",
     "http-proxy-middleware": "0.17.3",
-    "node-sass": "4.5.3",
+    "node-sass": "4.7.1",
     "opn": "5.1.0",
     "optimize-css-assets-webpack-plugin": "3.2.0",
     "ora": "1.2.0",


### PR DESCRIPTION
after upgrade node-sass version, fix  " Node Sass does not yet support your current environment " error.

windows 10 64Bit