### PR TITLE
Feature custom wizard icones

### DIFF
--- a/src/components/forms/form-wizard/FormWizard.vue
+++ b/src/components/forms/form-wizard/FormWizard.vue
@@ -284,9 +284,7 @@
           {
             label: this.$t('forms.wizard.stepOne'),
             slot: 'page1',
-            icons: {
-              both: 'ion ion-md-information-circle'
-            },
+            icons: 'ion ion-md-information-circle',
             onNext: () => {
               this.validateFormField('hrName')
             },
@@ -311,9 +309,7 @@
           {
             label: this.$t('forms.wizard.stepThree'),
             slot: 'page3',
-            icons: {
-              both: 'ion ion-logo-tux'
-            }
+            icons: 'ion ion-logo-tux'
           }
         ]
       },

--- a/src/components/forms/form-wizard/FormWizard.vue
+++ b/src/components/forms/form-wizard/FormWizard.vue
@@ -284,6 +284,9 @@
           {
             label: this.$t('forms.wizard.stepOne'),
             slot: 'page1',
+            icons: {
+              both: 'ion ion-md-information-circle'
+            },
             onNext: () => {
               this.validateFormField('hrName')
             },
@@ -294,6 +297,10 @@
           {
             label: this.$t('forms.wizard.stepTwo'),
             slot: 'page2',
+            icons: {
+              pending: 'fa fa-flag-o',
+              success: 'fa fa-flag'
+            },
             onNext: () => {
               this.$refs.hrCountrySelect.validate()
             },
@@ -303,7 +310,10 @@
           },
           {
             label: this.$t('forms.wizard.stepThree'),
-            slot: 'page3'
+            slot: 'page3',
+            icons: {
+              both: 'ion ion-logo-tux'
+            }
           }
         ]
       },

--- a/src/components/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
+++ b/src/components/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
@@ -1,8 +1,8 @@
 <template>
     <ul class="wizard-steps horizontal-steps rich-steps" :class="{'completed': completed}">
       <li class="wizard-step" :class="{'active': currentStep >= index, 'current': currentStep === index}" :style="{ width: 100/steps.length + '%' }" v-for="(step, index) of steps">
-        <i class="ion ion-md-close step-icon icon-cross"></i>
-        <i class="ion ion-md-checkmark step-icon icon-check"></i>
+        <i class="step-icon icon-cross" :class="pending(step)"></i>
+        <i class="step-icon icon-check" :class="success(step)"></i>
         <span class="wizard-step-label ellipsis">{{step.label}}</span>
         <span class="wizard-step-line"></span>
       </li>
@@ -24,6 +24,34 @@
       completed: {
         type: Boolean,
         default: false
+      }
+    },
+    methods: {
+      pending (step) {
+        if (step.hasOwnProperty('icons')) {
+          if (step.icons.hasOwnProperty('both')) {
+            return step.icons.both
+          } else if (step.icons.hasOwnProperty('pending')) {
+            return step.icons.pending
+          } else {
+            return 'ion ion-md-close'
+          }
+        } else {
+          return 'ion ion-md-close'
+        }
+      },
+      success (step) {
+        if (step.hasOwnProperty('icons')) {
+          if (step.icons.hasOwnProperty('both')) {
+            return step.icons.both
+          } else if (step.icons.hasOwnProperty('success')) {
+            return step.icons.success
+          } else {
+            return 'ion ion-md-checkmark'
+          }
+        } else {
+          return 'ion ion-md-checkmark'
+        }
       }
     }
   }

--- a/src/components/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
+++ b/src/components/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
@@ -29,8 +29,8 @@
     methods: {
       pending (step) {
         if (step.hasOwnProperty('icons')) {
-          if (step.icons.hasOwnProperty('both')) {
-            return step.icons.both
+          if ((typeof step.icons) === 'string') {
+            return step.icons
           } else if (step.icons.hasOwnProperty('pending')) {
             return step.icons.pending
           } else {
@@ -42,8 +42,8 @@
       },
       success (step) {
         if (step.hasOwnProperty('icons')) {
-          if (step.icons.hasOwnProperty('both')) {
-            return step.icons.both
+          if ((typeof step.icons) === 'string') {
+            return step.icons
           } else if (step.icons.hasOwnProperty('success')) {
             return step.icons.success
           } else {

--- a/src/components/vuestic-components/vuestic-wizard/indicators/RichVerticalIndicator.vue
+++ b/src/components/vuestic-components/vuestic-wizard/indicators/RichVerticalIndicator.vue
@@ -2,8 +2,8 @@
     <ul class="wizard-steps horizontal-steps rich-steps" :class="{'completed': completed}">
       <li class="wizard-step" :class="{'active': currentStep >= index, 'current': currentStep === index}" :style="{ height: 100/steps.length + '%' }" v-for="(step, index) of steps">
         <span class="wizard-step-line"></span>
-        <i class="ion ion-md-close step-icon icon-cross"></i>
-        <i class="ion ion-md-checkmark step-icon icon-check"></i>
+        <i class="step-icon icon-cross" :class="pending(step)"></i>
+        <i class="step-icon icon-check" :class="success(step)"></i>
         <span class="wizard-step-label ellipsis">{{step.label}}</span>
       </li>
     </ul>
@@ -24,6 +24,34 @@
       completed: {
         type: Boolean,
         default: false
+      }
+    },
+    methods: {
+      pending (step) {
+        if (step.hasOwnProperty('icons')) {
+          if (step.icons.hasOwnProperty('both')) {
+            return step.icons.both
+          } else if (step.icons.hasOwnProperty('pending')) {
+            return step.icons.pending
+          } else {
+            return 'ion ion-md-close'
+          }
+        } else {
+          return 'ion ion-md-close'
+        }
+      },
+      success (step) {
+        if (step.hasOwnProperty('icons')) {
+          if (step.icons.hasOwnProperty('both')) {
+            return step.icons.both
+          } else if (step.icons.hasOwnProperty('success')) {
+            return step.icons.success
+          } else {
+            return 'ion ion-md-checkmark'
+          }
+        } else {
+          return 'ion ion-md-checkmark'
+        }
       }
     }
   }

--- a/src/components/vuestic-components/vuestic-wizard/indicators/RichVerticalIndicator.vue
+++ b/src/components/vuestic-components/vuestic-wizard/indicators/RichVerticalIndicator.vue
@@ -29,8 +29,8 @@
     methods: {
       pending (step) {
         if (step.hasOwnProperty('icons')) {
-          if (step.icons.hasOwnProperty('both')) {
-            return step.icons.both
+          if ((typeof step.icons) === 'string') {
+            return step.icons
           } else if (step.icons.hasOwnProperty('pending')) {
             return step.icons.pending
           } else {
@@ -42,8 +42,8 @@
       },
       success (step) {
         if (step.hasOwnProperty('icons')) {
-          if (step.icons.hasOwnProperty('both')) {
-            return step.icons.both
+          if ((typeof step.icons) === 'string') {
+            return step.icons
           } else if (step.icons.hasOwnProperty('success')) {
             return step.icons.success
           } else {


### PR DESCRIPTION
I have added a property in the steps that allows you to choose a custom icon for the step
```javascript
icons: 'class add for the 2 states'
---
icons: {
     pending: 'class add for the pending state'
     success: 'class add for the success state'
}
```

the default icons stay the same, no obligation to use custom icons