### PR TITLE
feat(language-selector): add vuestic-language-selector component

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "detect-browser": "^1.7.1",
     "element-resize-detector": "^1.1.12",
     "epic-spinners": "^1.0.1",
+    "flag-icon-css": "^2.9.0",
     "font-awesome": "^4.7.0",
     "gemini-scrollbar": "^1.5.1",
     "google-maps": "^3.2.1",

--- a/src/components/layout/navbar/LanguageSelector.vue
+++ b/src/components/layout/navbar/LanguageSelector.vue
@@ -1,0 +1,171 @@
+<template>
+  <div class="language-selector dropdown" v-dropdown.closeOnMenuClick>
+    <a class="language-selector-button dropdown-toggle" href="#" @click.prevent="closeMenu">
+      <i class="flag-icon flag-icon-large" :class="flagIconClass(currentLanguage())"></i>
+    </a>
+    <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+      <a
+        class="dropdown-item"
+        :class="{ active: option.code === currentLanguage() }"
+        v-for="(option, id) in options"
+        :key="id"
+        @click="setLanguage(option.code)"
+      >
+        <i class="flag-icon flag-icon-small" :class="flagIconClass(option.code)"></i>
+        <span class="dropdown-item-text ellipsis">
+          {{ `language.${option.name}` | translate }}
+        </span>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+  import Vue from 'vue'
+  import { mapActions } from 'vuex'
+  import Dropdown from '../../../directives/Dropdown'
+
+  export default {
+    name: 'language-selector',
+
+    directives: {
+      dropdown: Dropdown
+    },
+
+    props: {
+      options: {
+        type: Array,
+        required: true
+      }
+    },
+
+    methods: {
+      ...mapActions(['closeMenu']),
+
+      setLanguage (locale) {
+        Vue.i18n.set(locale)
+      },
+
+      currentLanguage () {
+        return Vue.i18n.locale() === 'en' ? 'gb' : Vue.i18n.locale()
+      },
+
+      flagIconClass (code) {
+        return `flag-icon-${code}`
+      }
+    }
+  }
+</script>
+
+<style lang="scss">
+  @import "../../../sass/variables";
+  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "../../../../node_modules/bootstrap/scss/functions";
+  @import "../../../../node_modules/bootstrap/scss/variables";
+
+  .language-selector {
+    display: flex;
+    max-width: 100%;
+    height: 100%;
+    padding: 0;
+    flex-basis: 0;
+    flex-grow: 1;
+    align-items: center;
+    justify-content: center;
+
+    .language-selector-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .flag-icon-large {
+      width: 31px;
+      height: 23px;
+    }
+
+    .flag-icon-small {
+      min-width: 22px;
+      height: 17px;
+    }
+
+    .dropdown-toggle {
+      padding: 0;
+
+      &:after {
+        display: none;
+      }
+    }
+
+    &.show {
+      &:after {
+        position: absolute;
+        right: calc(50% - 10px);
+        bottom: -$dropdown-mobile-show-b;
+        display: block;
+        width: 0;
+        height: 0;
+        content: '';
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+        border-bottom: 10px solid $darkest-gray;
+        z-index: 2;
+      }
+
+      .dropdown-menu {
+        left: auto;
+        margin-top: $dropdown-mobile-show-b;
+
+        &.last {
+          right: 0;
+        }
+
+        @include media-breakpoint-up(lg) {
+          right: auto;
+          left: 12px;
+          margin-top: 12px;
+        }
+      }
+    }
+
+    .dropdown-menu {
+      min-width: 8rem;
+      max-width: 11rem;
+      margin-top: $dropdown-show-b;
+      padding: 0;
+      background-color: $dropdown-background;
+      box-shadow: $dropdown-box-shadow;
+
+      @include media-breakpoint-up(lg) {
+        top: 42px;
+      }
+    }
+
+    .dropdown-item {
+      display: flex;
+      align-items: center;
+      height: 38px;
+      padding: 9px 12px;
+
+      &.active {
+        color: $vue-green;
+        background-color: $darkest-gray;
+      }
+      
+      &:hover {
+        background-color: $almost-black;
+      }
+
+      &:last-child {
+        padding-top: 8px;
+        padding-bottom: 10px;
+      }
+    }
+
+    .dropdown-item-text {
+      padding-left: 12px;
+      font-size: $font-size-base;
+      line-height: 1.25;
+    }
+  }
+</style>

--- a/src/components/layout/navbar/Navbar.vue
+++ b/src/components/layout/navbar/Navbar.vue
@@ -53,6 +53,7 @@
           </div>
         </div>
       </div>
+      <language-selector :options="langs"></language-selector>
       <div class="col nav-item dropdown navbar-dropdown d-flex align-items-center justify-content-center" v-dropdown>
         <a class="nav-link dropdown-toggle d-flex align-items-center justify-content" href="#" @click.prevent="closeMenu">
           <span class="avatar-container">
@@ -65,65 +66,59 @@
               <a class="plain-link" href="#">{{'user.profile' | translate}}</a>
             </div>
             <div class="dropdown-item plain-link-item">
-              <a class="plain-link" href="#" @click.prevent="showLanguageModal">{{'user.language' | translate}}</a>
-            </div>
-            <div class="dropdown-item plain-link-item">
               <a class="plain-link" href="#">{{'user.logout' | translate}}</a>
             </div>
           </div>
         </div>
       </div>
     </div>
-    <vuestic-modal ref="languageModal"
-     v-bind:small="true" :okClass="'none'" :cancelClass="'none'">
-      <div slot="title">{{'user.language' | translate}}</div>
-      <div class="text-center">
-              <button class="btn btn-info" @click="setLanguage('en')">
-                {{'language.english' | translate}}
-              </button>
-              <hr>
-              <button class="btn btn-info" @click="setLanguage('es')">
-                {{'language.spanish' | translate}}
-              </button>
-      </div>
-    </vuestic-modal>
   </nav>
 </template>
 
 <script>
-  import Vue from 'vue'
   import { mapGetters, mapActions } from 'vuex'
-  import Dropdown from 'directives/Dropdown'
+  import Dropdown from '../../../directives/Dropdown'
+  import LanguageSelector from './LanguageSelector'
 
   export default {
     name: 'navbar',
 
+    components: {
+      LanguageSelector
+    },
+
     directives: {
       dropdown: Dropdown
+    },
+
+    data () {
+      return {
+        langs: [
+          {
+            code: 'gb',
+            name: 'english'
+          },
+          {
+            code: 'es',
+            name: 'spanish'
+          }
+        ]
+      }
     },
 
     computed: {
       ...mapGetters([
         'sidebarOpened',
         'toggleWithoutAnimation'
-      ]),
-      currentLanguage () {
-        return Vue.i18n.locale() === 'en' ? 'English' : 'Spanish'
-      }
+      ])
     },
+
     methods: {
       ...mapActions([
         'closeMenu',
         'toggleSidebar',
         'isToggleWithoutAnimation'
-      ]),
-      showLanguageModal () {
-        this.$refs.languageModal.open()
-      },
-      setLanguage (locale) {
-        Vue.i18n.set(locale)
-        this.$refs.languageModal.cancel()
-      }
+      ])
     }
   }
 </script>

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -8,6 +8,7 @@
 @import "~font-awesome/css/font-awesome.css";
 
 @import "~ionicons/dist/css/ionicons.css";
+@import "~flag-icon-css/css/flag-icon.css";
 @import "~awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.scss";
 @import "~medium-editor/src/sass/medium-editor";
 @import "_icons-styles.scss";


### PR DESCRIPTION
This PR adds `language-selector` component, includes it to navbar and removes `Change Language` section from `User Profile` dropdown in navbar. It uses `flag-icon-css` library for country flags in SVG.

