### PR TITLE
Shorten the build context for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 node_modules/
+dist/
 .git/
 .dockerignore
 .gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
-node_modules
+node_modules/
+.git/
+.dockerignore
+.gitattributes
+.gitignore
+Dockerfile
+README.md


### PR DESCRIPTION
Shorten the build context and improve docker cache. eg: if something change in .git, the `COPY` command in the Dockerfile won't invalidate the cache.