### PR TITLE
Use `novalidate` to avoid the `required` validation popup

### DIFF
--- a/src/components/forms/form-elements/FormElements.vue
+++ b/src/components/forms/form-elements/FormElements.vue
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-12">
         <vuestic-widget :headerText="'forms.inputs.title' | translate">
-          <form>
+          <form novalidate>
 
             <div class="row">
               <div class="col-md-4">


### PR DESCRIPTION
It seems the `required` attribute in the inputs is only used to change the label with css pseudo-classes (eg: `:valid`). Due to we are delegating the validation to vee-validate, we need to disallow the browser validation.  
