### PR TITLE
Fix ionicon icons

### DIFF
--- a/src/components/dashboard/DashboardInfoWidgets.vue
+++ b/src/components/dashboard/DashboardInfoWidgets.vue
@@ -5,7 +5,7 @@
         <div class="info-widget-inner">
           <div class="stats">
             <div class="stats-number">
-              <i class="ion ion-arrow-up-c text-primary stats-icon"></i>
+              <i class="ion ion-md-arrow-up text-primary stats-icon"></i>
               59
             </div>
             <div class="stats-title">{{'dashboard.elements' | translate}}</div>
@@ -18,7 +18,7 @@
         <div class="info-widget-inner">
           <div class="stats">
             <div class="stats-number">
-              <i class="ion ion-arrow-down-c text-danger stats-icon"></i>
+              <i class="ion ion-md-arrow-down text-danger stats-icon"></i>
               12
             </div>
             <div class="stats-title">{{'dashboard.versions' | translate}}</div>
@@ -49,7 +49,7 @@
         <div class="info-widget-inner">
           <div class="stats">
             <div class="stats-number">
-              <i class="ion ion-android-people stats-icon icon-wide"></i>
+              <i class="ion ion-md-people stats-icon icon-wide"></i>
               5
             </div>
             <div class="stats-title">{{'dashboard.teamMembers' | translate}}</div>

--- a/src/vuestic-theme/vuestic-components/vuestic-multi-select/VuesticMultiSelect.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-multi-select/VuesticMultiSelect.vue
@@ -8,7 +8,7 @@
         :class="{'has-value': !!displayValue}"
         v-bind:value="displayValue"
         required/>
-      <i class="ion ion-chevron-down icon-right input-icon"></i>
+      <i class="ion ion-ios-arrow-down icon-right input-icon"></i>
       <label class="control-label">{{label}}</label><i class="bar"></i>
       <small v-show="hasErrors()" class="help text-danger">{{ showRequiredError() }}</small>
     </div>

--- a/src/vuestic-theme/vuestic-components/vuestic-simple-select/VuesticSimpleSelect.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-simple-select/VuesticSimpleSelect.vue
@@ -9,7 +9,7 @@
         v-model="displayValue"
         :name="name"
         required/>
-      <i class="ion ion-chevron-down icon-right input-icon"></i>
+      <i class="ion ion-ios-arrow-down icon-right input-icon"></i>
       <label class="control-label">{{label}}</label><i class="bar"></i>
       <small v-show="hasErrors()" class="help text-danger">{{ showRequiredError() }}</small>
     </div>


### PR DESCRIPTION
Fix some of the icon names that were obsoleted with ionicons 3.0.0.

Refer to [this cheatsheet](https://cdn.rawgit.com/driftyco/ionicons/3.0/cheatsheet.html) to see the new names.