### PR TITLE
Improve file importing from node_modules

### DIFF
--- a/src/components/auth/login/Login.vue
+++ b/src/components/auth/login/Login.vue
@@ -32,9 +32,9 @@
 
 <style lang="scss">
   @import '../../../sass/variables';
-  @import '../../../../node_modules/bootstrap/scss/mixins/breakpoints';
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import '../../../../node_modules/bootstrap/scss/variables';
+  @import '~bootstrap/scss/mixins/breakpoints';
+  @import "~bootstrap/scss/functions";
+  @import '~bootstrap/scss/variables';
   .login {
     @include media-breakpoint-down(md) {
       width: 100%;

--- a/src/components/auth/signup/Signup.vue
+++ b/src/components/auth/signup/Signup.vue
@@ -38,9 +38,9 @@
 
 <style lang="scss">
   @import '../../../sass/variables';
-  @import '../../../../node_modules/bootstrap/scss/mixins/breakpoints';
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import '../../../../node_modules/bootstrap/scss/variables';
+  @import '~bootstrap/scss/mixins/breakpoints';
+  @import "~bootstrap/scss/functions";
+  @import '~bootstrap/scss/variables';
 
   .signup {
     @include media-breakpoint-down(md) {

--- a/src/components/dashboard/data-visualisation-tab/DataVisualisation.vue
+++ b/src/components/dashboard/data-visualisation-tab/DataVisualisation.vue
@@ -56,9 +56,9 @@
 
 <style lang="scss" scoped>
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   .chart-container {
     padding: 0 2rem;

--- a/src/components/dashboard/features-tab/FeaturesTab.vue
+++ b/src/components/dashboard/features-tab/FeaturesTab.vue
@@ -55,9 +55,9 @@
 
 <style lang="scss" scoped>
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   .overview-item {
     display: flex;

--- a/src/components/dashboard/setup-profile-tab/SetupProfileTab.vue
+++ b/src/components/dashboard/setup-profile-tab/SetupProfileTab.vue
@@ -120,9 +120,9 @@
 
 <style lang="scss" scoped>
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   .form-group {
     min-width: 200px;

--- a/src/components/dashboard/users-and-members-tab/UsersMembersTab.vue
+++ b/src/components/dashboard/users-and-members-tab/UsersMembersTab.vue
@@ -53,9 +53,9 @@
 
 <style lang="scss" scoped>
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
 
   .vuestic-profile-card {

--- a/src/components/forms/form-wizard/FormWizard.vue
+++ b/src/components/forms/form-wizard/FormWizard.vue
@@ -391,9 +391,9 @@
 
 <style lang="scss">
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   .widget.simple-vertical-wizard-widget {
     .widget-body {

--- a/src/components/layout/AuthLayout.vue
+++ b/src/components/layout/AuthLayout.vue
@@ -21,9 +21,9 @@
 
 <style lang="scss">
   @import '../../sass/variables';
-  @import '../../../node_modules/bootstrap/scss/mixins/breakpoints';
-  @import "../../../node_modules/bootstrap/scss/functions";
-  @import '../../../node_modules/bootstrap/scss/variables';
+  @import '~bootstrap/scss/mixins/breakpoints';
+  @import "~bootstrap/scss/functions";
+  @import '~bootstrap/scss/variables';
   .auth-layout {
     height: 100vh;
     margin: 0;

--- a/src/components/layout/Layout.vue
+++ b/src/components/layout/Layout.vue
@@ -55,9 +55,9 @@
 
 <style lang="scss">
   @import "../../sass/_variables.scss";
-  @import "../../../node_modules/bootstrap/scss/mixins/breakpoints";
-  @import "../../../node_modules/bootstrap/scss/functions";
-  @import "../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .content-wrap {
     margin-left: $content-wrap-ml;

--- a/src/components/layout/navbar/LanguageSelector.vue
+++ b/src/components/layout/navbar/LanguageSelector.vue
@@ -54,9 +54,9 @@
 
 <style lang="scss">
   @import "../../../sass/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .language-selector {
     display: flex;

--- a/src/components/layout/navbar/Navbar.vue
+++ b/src/components/layout/navbar/Navbar.vue
@@ -123,9 +123,9 @@
 
 <style lang="scss">
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .navbar.app-navbar {
     .navbar-container {

--- a/src/components/layout/sidebar/Sidebar.vue
+++ b/src/components/layout/sidebar/Sidebar.vue
@@ -98,9 +98,9 @@
 
 <style lang="scss">
 @import "../../../sass/_variables.scss";
-@import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
-@import "../../../../node_modules/bootstrap/scss/functions";
-@import "../../../../node_modules/bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins/breakpoints";
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
 
 .sidebar {
   @include media-breakpoint-down(md) {

--- a/src/components/maps/bubble-maps/BubbleMap.vue
+++ b/src/components/maps/bubble-maps/BubbleMap.vue
@@ -99,7 +99,7 @@
 
 <style lang='scss'>
   @import '../../../sass/_variables.scss';
-  @import '../../../../node_modules/ammap3/ammap/ammap.css';
+  @import '~ammap3/ammap/ammap.css';
 
   .bubble-map {
     height: 100%;

--- a/src/components/maps/leaflet-maps/LeafletMap.vue
+++ b/src/components/maps/leaflet-maps/LeafletMap.vue
@@ -28,7 +28,7 @@
 </script>
 
 <style lang="scss">
-  @import "../../../../node_modules/leaflet/dist/leaflet.css";
+  @import "~leaflet/dist/leaflet.css";
   @import "../../../sass/_variables.scss";
 
   .leaflet-map {

--- a/src/components/maps/line-maps/LineMap.vue
+++ b/src/components/maps/line-maps/LineMap.vue
@@ -62,7 +62,7 @@
 
 <style lang='scss'>
   @import '../../../sass/_variables.scss';
-  @import '../../../../node_modules/ammap3/ammap/ammap.css';
+  @import '~ammap3/ammap/ammap.css';
 
   .line-map {
     height: 100%;

--- a/src/components/statistics/progress-bars/ProgressBars.vue
+++ b/src/components/statistics/progress-bars/ProgressBars.vue
@@ -132,8 +132,8 @@
 
 <style lang="scss">
   @import "../../../sass/variables";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
   @import "../../../sass/mixins";
 
   .progress-bars {

--- a/src/components/ui/buttons/Buttons.vue
+++ b/src/components/ui/buttons/Buttons.vue
@@ -194,9 +194,9 @@
 </script>
 
 <style lang="scss">
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .buttons-page {
     @include media-breakpoint-only(xl) {

--- a/src/components/ui/icons/Set.vue
+++ b/src/components/ui/icons/Set.vue
@@ -96,9 +96,9 @@
 
 <style lang="scss">
   @import "../../../sass/variables";
-  @import '../../../../node_modules/bootstrap/scss/mixins/breakpoints';
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import '../../../../node_modules/bootstrap/scss/variables';
+  @import '~bootstrap/scss/mixins/breakpoints';
+  @import "~bootstrap/scss/functions";
+  @import '~bootstrap/scss/variables';
 
   .Set{
     .header {

--- a/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
@@ -140,8 +140,8 @@
 
 <style lang="scss" scoped>
   @import "../../../sass/_variables.scss";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   // For Transitioning
   .modal {

--- a/src/vuestic-theme/vuestic-components/vuestic-progress-bar/VuesticProgressBar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-progress-bar/VuesticProgressBar.vue
@@ -95,8 +95,8 @@
 <style lang="scss">
   @import "../../../sass/variables";
   @import "../../../sass/mixins";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .vuestic-progress-bar {
     font-size: $progress-bar-value-font-size;

--- a/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/CircleProgressBar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/CircleProgressBar.vue
@@ -37,8 +37,8 @@
 <style lang="scss">
   @import "../../../../sass/variables";
   @import "../../../../sass/mixins";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .vuestic-progress-bar .circle {
     $step: 1;

--- a/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/HorizontalProgressBar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/HorizontalProgressBar.vue
@@ -43,8 +43,8 @@
 <style lang="scss">
   @import "../../../../sass/variables";
   @import "../../../../sass/mixins";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .vuestic-progress-bar .horizontal {
     display: inline-block;

--- a/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/VerticalProgressBar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-progress-bar/progress-types/VerticalProgressBar.vue
@@ -40,8 +40,8 @@
 <style lang="scss">
   @import "../../../../sass/variables";
   @import "../../../../sass/mixins";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
 
   .vuestic-progress-bar .vertical {
 

--- a/src/vuestic-theme/vuestic-components/vuestic-social-news/VuesticSocialNews.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-social-news/VuesticSocialNews.vue
@@ -21,9 +21,9 @@
 
 <style lang="scss">
   @import "../../../sass/variables";
-  @import "../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   .business-posts .widget-body {
     padding-left: 2rem;

--- a/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/RichHorizontalIndicator.vue
@@ -31,9 +31,9 @@
 
 <style lang="scss" scoped>
   @import "../../../../sass/_variables.scss";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   $wizard-step-height: 5.5rem;
   $wizard-step-label-font-size: $font-size-h4;

--- a/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/SimpleHorizontalIndicator.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/SimpleHorizontalIndicator.vue
@@ -31,9 +31,9 @@
 
 <style lang="scss" scoped>
   @import "../../../../sass/_variables.scss";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   $wizard-step-height: 3.75rem;
   $wizard-step-indicator-height: 1rem;

--- a/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/SimpleVerticalIndicator.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-wizard/indicators/SimpleVerticalIndicator.vue
@@ -31,9 +31,9 @@
 
 <style lang="scss" scoped>
   @import "../../../../sass/variables";
-  @import "../../../../../node_modules/bootstrap/scss/functions";
-  @import "../../../../../node_modules/bootstrap/scss/variables";
-  @import "../../../../../node_modules/bootstrap/scss/mixins/breakpoints";
+  @import "~bootstrap/scss/functions";
+  @import "~bootstrap/scss/variables";
+  @import "~bootstrap/scss/mixins/breakpoints";
 
   $wizard-steps-height: 100%;
   $wizard-steps-width: 100%;


### PR DESCRIPTION
Import sass files _consistently_ through webpack `~` mechanism. [Reference](https://webpack.js.org/loaders/sass-loader/#imports).