### PR TITLE
added close function in modal component

### DIFF
--- a/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
@@ -153,6 +153,10 @@ export default {
     open () {
       this.show = true
       window.addEventListener('keyup', this.listenKeyUp)
+    },
+    close () {
+      this.show = false
+      window.removeEventListener('keyup', this.listenKeyUp)
     }
   }
 }


### PR DESCRIPTION
In the `vuestic-modal` component there is not a close function and I think it is a good idea to have it.