### PR TITLE
Refactor/colors refactor

### DIFF
--- a/src/vuestic-theme/vuestic-components/vuestic-breadcrumbs/VuesticBreadcrumbs.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-breadcrumbs/VuesticBreadcrumbs.vue
@@ -70,6 +70,10 @@ export default {
 </script>
 
 <style lang='scss'>
+$breadcrumbs-height: 54px;
+$breadcrumbs-arrow-font: 0.7rem;
+$breadcrumbs-arrow-content: "\f054";
+
 .vuestic-breadcrumbs {
   min-height: $breadcrumbs-height;
   display: flex;

--- a/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
@@ -39,6 +39,9 @@ export default {
 </script>
 
 <style lang="scss">
+$vuestic-preloader-left: calc(50% - 140px / 2);
+$vuestic-preloader-top: calc(50% - 104px / 2);
+
 .vuestic-layout {
   &-fixed {
     .content-wrap {

--- a/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue
@@ -170,13 +170,10 @@ $modal-header-padding-x: $widget-padding;
 $modal-header-padding-y: 0;
 $modal-header-height: $widget-header-height;
 $modal-header-border: $widget-header-border;
-$modal-content-border-width: 0;
 $modal-content-border-radius: 0;
 $modal-inner-padding: 25px;
 $modal-footer-btns-padding-bottom: 20px;
 $modal-footer-btns-margin-x: 10px;
-$modal-md: 650px;
-$modal-lg: 850px;
 
 .vuestic-modal {
   height: 0;

--- a/src/vuestic-theme/vuestic-components/vuestic-navbar/VuesticNavbar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-navbar/VuesticNavbar.vue
@@ -28,6 +28,15 @@ export default {
 </script>
 
 <style lang="scss">
+$nav-mobile-padding-h: .875rem;
+$nav-mobile-pt: 1.75rem;
+$nav-mobile-pb: 0.5rem;
+$nav-mobile-brand-width: 4rem;
+$nav-mobile-brand-top: .875rem;
+$nav-mobile-brand-left: calc(50% - #{$nav-mobile-brand-width});
+$dropdown-mobile-show-b: 2rem;
+$navbar-dd-item-height: 48px;
+
 .vuestic-navbar {
   .layout-fixed & {
     position: fixed;

--- a/src/vuestic-theme/vuestic-components/vuestic-switch/VuesticSwitch.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-switch/VuesticSwitch.vue
@@ -29,6 +29,10 @@ export default {
 </script>
 
 <style lang="scss">
+$vuestic-switch-bg: $brand-primary;
+$vuestic-switch-padding: 0.313rem 2.375rem;
+$vuestic-switch-border-size: 0.125rem;
+
 .vuestic-switch {
   cursor: pointer;
   display: flex;

--- a/src/vuestic-theme/vuestic-sass/global/_typography.scss
+++ b/src/vuestic-theme/vuestic-sass/global/_typography.scss
@@ -1,3 +1,11 @@
+// Links
+$va-link-color: $brand-primary;
+$va-link-color-secondary: #babfc2;
+$va-link-color-hover: #79eca8;
+$va-link-color-active: #48c279;
+$va-link-color-visited: $va-link-color;
+$link-hover-decoration: none;
+
 .vue-highlighted-text {
   background-color: $vue-turquoise;
 }

--- a/src/vuestic-theme/vuestic-sass/icons/_fonts.scss
+++ b/src/vuestic-theme/vuestic-sass/icons/_fonts.scss
@@ -1,3 +1,9 @@
+//Icons
+$bootstrap-sass-asset-helper: false;
+$icon-font-name: 'glyphicons-halflings-regular';
+$icon-font-svg-id: 'glyphicons_halflingsregular';
+$icon-font-path: './fonts/';
+
 // Fonts //
 @import url(https://fonts.googleapis.com/css?family=Source+Sans+Pro);
 

--- a/src/vuestic-theme/vuestic-sass/resources/_variables.scss
+++ b/src/vuestic-theme/vuestic-sass/resources/_variables.scss
@@ -58,7 +58,6 @@ $theme-colors: (
 );
 
 // Layout //
-$body-bg: $light-gray;
 $top-nav-bg: $darkest-gray;
 $body-color: $vue-darkest-blue !default;
 $layout-padding: 24px;
@@ -75,8 +74,6 @@ $sidebar-top: calc(#{$top-nav-height} + #{$layout-padding});
 $sidebar-left: $layout-padding;
 
 $content-wrap-ml: calc(#{$sidebar-left} + #{$sidebar-width} + 35px);
-$content-wrap-pr: $layout-padding-right;
-$content-wrap-pt: $layout-padding;
 $content-wrap-pb: $layout-padding;
 $made-by-footer-pb: 27px;
 
@@ -101,16 +98,14 @@ $layout-mobile-padding-right: .375rem;
 $sidebar-mobile-width: calc(100% - #{$layout-mobile-padding-right});
 $sidebar-mobile-top: $top-mobile-nav-height+$layout-mobile-padding;
 $sidebar-mobile-left: $layout-mobile-padding;
-$content-mobile-wrap-margin: 1.125rem;
 $sidebar-mobile-z-index: 1000;
 
 $content-mobile-wrap-pl: 1rem;
 $content-mobile-wrap-pr: 1rem;
 $content-mobile-wrap-pt: 2rem;
-$content-mobile-wrap-pt-fixed-layout: 7rem;
 $content-mobile-wrap-pb: $layout-padding;
 $content-mobile-wrap: $content-mobile-wrap-pt $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
-$content-mobile-wrap-fixed-layout: $content-mobile-wrap-pt-fixed-layout $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
+$content-mobile-wrap-fixed-layout: 7rem $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
 $content-mobile-wrap-sb-top: calc(#{$top-nav-height} + #{$layout-padding+20}) - 20 px;
 
 $nav-mobile-padding-h: .875rem;
@@ -120,7 +115,6 @@ $nav-mobile-brand-width: 4rem;
 $nav-mobile-brand-top: .875rem;
 $nav-mobile-brand-left: calc(50% - #{$nav-mobile-brand-width});
 
-$droppdown-mobile-mp: 1.9375rem;
 $dropdown-mobile-show-b: 2rem;
 
 //Auth mobile
@@ -161,6 +155,7 @@ $blockquote-border-color: $vue-green;
 $blockquote-small-color: $gray-light;
 $blockquote-border-width: 0.375rem;
 $blockquote-font-size: 1.5rem;
+
 //Navbar
 $navbar-dd-item-height: 48px;
 
@@ -177,7 +172,7 @@ $sidebar-submenu-link-pl: 74px;
 $sidebar-link-active-bg: $almost-black;
 $sidebar-arrow-right: 16px;
 $sidebar-menu-item-icon-size: 19px;
-$sidebar-viewport-height: calc(100vh - #{$top-nav-height} - #{$content-wrap-pt} - #{$content-wrap-pb});
+$sidebar-viewport-height: calc(100vh - #{$top-nav-height} - #{$layout-padding} - #{$content-wrap-pb});
 
 $sidebar-hidden-top: -150px;
 $sidebar-hidden-top-mobile: $sidebar-mobile-top;
@@ -188,7 +183,7 @@ $sidebar-box-shadow: 0px 8px 14.72px 1.28px rgba(#65a977, 0.3);
 $widget-bg: $white;
 $widget-padding: 1.5625rem;
 $widget-larger-padding: 45px;
-$widget-box-shadow: 0px 4px 70px -18px rgba(112, 112, 112, 1);
+$widget-box-shadow: 0px 4px 70px -18px #707070;
 $widget-danger-shadow: 0px 4px 70px -16px $brand-danger;
 $widget-info-shadow: 0px 4px 70px -16px $brand-info;
 $widget-viewport-height: $sidebar-viewport-height;
@@ -199,17 +194,7 @@ $widget-body-with-header-height: calc(100% - #{$widget-header-height});
 $widget-mb: 1.875rem;
 $info-widget-border: 0.5rem solid $brand-primary;
 
-// Links
-$va-link-color: $brand-primary;
-$va-link-color-secondary: #babfc2;
-$va-link-color-hover: #79eca8;
-$va-link-color-active: #48c279;
-$va-link-color-visited: $va-link-color;
-$link-hover-decoration: none;
-
-
 //Buttons
-$input-btn-border-width: 0px;
 $btn-line-height: 1.25;
 $btn-line-height-sm: $btn-line-height;
 $btn-padding-x: 3.9rem;
@@ -237,51 +222,19 @@ $btn-box-info-shadow: 0px 4px 70px -16px $brand-info;
 $btn-box-pale-shadow: 0px 4px 70px -16px $theme-pale;
 $btn-box-dark-shadow: 0px 4px 70px -16px $almost-black;
 $btn-border-radius: 1.875rem;
-$btn-dark-color: $white;
-$btn-dark-bg: $darkest-gray;
-$btn-dark-border: $darkest-gray;
-$btn-pale-bg: $theme-pale;
-$btn-pale-color: $white;
 $btn-dd-arrow-size: 1rem;
 $btn-border: none;
 $btn-secondary-theme-border: 2px solid $brand-primary;
 
 //Dropdowns
-$dropdown-link-color: $white;
 $dropdown-box-shadow: $greeny-box-shadow;
 $dropdown-background: $darkest-gray;
-$dropdown-link-color: $white;
-$dropdown-link-hover-color: $white;
-$dropdown-link-hover-bg: $almost-black;
-$dropdown-link-active-color: $white;
-$dropdown-link-active-bg: $almost-black;
-$dropdown-item-padding-x: 25px;
-$dropdown-item-padding-y: 0;
 $dropdown-item-height: 40px;
 $dropdown-menu-padding-y: 10px;
 $dropdown-menu-padding-x: 0;
-$dropdown-min-width: 15rem;
-$dropdown-simple-visible-items: 4;
-$dropdown-multi-visible-items: 4;
 $dropdown-show-b: 1.125rem;
 
-//Modals
-$modal-header-padding-x: $widget-padding;
-$modal-header-padding-y: 0;
-$modal-header-height: $widget-header-height;
-$modal-header-border: $widget-header-border;
-$modal-content-border-width: 0;
-$modal-content-border-radius: 0;
-$modal-inner-padding: 25px;
-$modal-footer-btns-padding-bottom: 20px;
-$modal-footer-btns-margin-x: 10px;
-$modal-md: 650px;
-$modal-lg: 850px;
-
 //Forms
-$input-border-color: $lighter-gray;
-$input-bg-disabled: $white;
-
 $vuestic-switch-bg: $brand-primary;
 $vuestic-switch-padding: 0.313rem 2.375rem;
 $vuestic-switch-border-size: 0.125rem;
@@ -298,35 +251,18 @@ $progress-bar-width-thick: 1.5rem;
 $vertical-progress-bar-width-thick: 2rem;
 
 //Tables
-$table-bg-accent: $white;
-$table-border-width: 0;
 $table-border-color: #eceeef;
 $striped-row-odd: $white;
 $striped-row: $light-gray2;
-$state-success-bg: #c8fac6;
-$state-danger-bg: #ffcece;
-$state-warning-bg: #fff1c8;
 $state-info-bg: #dcf1ff;
 $table-hover-bg: rgba($vue-green, .5);
-$table-active-bg: $table-hover-bg;
 
 //Badges
-$badge-padding-y: 0.28rem;
 $badge-min-width: 5rem;
-$badge-font-size: 0.7rem;
 $badge-success-bg: $brand-success;
-$badge-warning-bg: $theme-orange;
-$badge-danger-bg: $theme-red;
-$badge-info-bg: $theme-blue;
 
 //Alerts
-$alert-padding-x: 1.25rem !default;
-$alert-padding-y: .75rem !default;
-$alert-margin-bottom: $widget-mb;
 $with-close-pr: 3.125rem;
-
-$alert-border-radius: 0;
-$alert-border-width: 0;
 
 $alert-success-bg: $light-green;
 $alert-success-text: $body-color;
@@ -348,12 +284,6 @@ $alert-danger-text: $body-color;
 $alert-danger-border: transparent;
 $alert-danger-shadow: 0px 4px 9.6px 0.4px rgba(206, 79, 79, 0.5);
 
-//Icons
-$bootstrap-sass-asset-helper: false;
-$icon-font-name: 'glyphicons-halflings-regular';
-$icon-font-svg-id: 'glyphicons_halflingsregular';
-$icon-font-path: './fonts/';
-
 //Tabs
 
 $tab-content-pt: 3.125rem;
@@ -368,68 +298,34 @@ $medium-editor-button-size: $btn-padding-y * 2 + $font-size-base * $btn-line-hei
 
 //tooltips
 
-$tooltip-font-size: $font-size-base;
 $tooltip-box-shadow: $greeny-box-shadow;
-$tooltip-max-width: 200px;
-$tooltip-color: $white;
-$tooltip-bg: $darkest-gray;
-$tooltip-border-radius: $font-size-base * 0.5;
-$tooltip-opacity: .9;
-$tooltip-padding-y: .5rem;
-$tooltip-padding-x: .75rem;
-$tooltip-margin: 0;
 $tooltip-line-height: 1.13;
 $tooltip-font-weight: 300;
 
-$tooltip-arrow-width: .8rem;
-$tooltip-arrow-height: .4rem;
-$tooltip-arrow-color: $tooltip-bg;
-
 // Popovers
 
-$popover-font-size: $font-size-base;
 $popover-line-height: $tooltip-line-height;
 $popover-box-shadow: $tooltip-box-shadow;
-$popover-bg: $tooltip-bg;
-$popover-max-width: 400px;
-$popover-border-width: 0;
-$popover-border-color: transparent;
-$popover-border-radius: $tooltip-border-radius;
 $popover-box-shadow: $greeny-box-shadow;
-$popover-opacity: $tooltip-opacity;
 
-$popover-header-bg: $tooltip-bg;
-$popover-header-color: $white;
-$popover-header-padding-y: 0;
-$popover-header-padding-x: .75rem;
 $popover-header-no-icon-padding-x: 0;
 $popover-header-font-weight: bold;
 
-$popover-body-color: $white;
-$popover-body-padding-y: $popover-header-padding-y;
-$popover-body-padding-x: $popover-header-padding-x;
-$popover-body-no-icon-padding-x: $popover-header-no-icon-padding-x;
+$popover-body-padding-y: 0;
 
 $popover-icon-size: 1.35rem;
 $popover-icon-color: $brand-primary;
 
-$popover-arrow-width: 1rem;
-$popover-arrow-height: 1rem;
-$popover-arrow-color: transparent;
-
-$popover-arrow-outer-color: fade-in($popover-border-color, .05);
-
 // Toasts
 
-$toast-font-size: $popover-font-size;
+$toast-font-size: $font-size-base;
 $toast-line-height: $popover-line-height;
 $toast-font-weight: normal;
 $toast-min-height: 3.25rem;
 $toast-box-shadow: $popover-box-shadow;
-$toast-bg: $popover-bg;
-$toast-border-radius: $popover-border-radius;
-$toast-color: $popover-body-color;
-$toast-opacity: $popover-opacity;
+$toast-bg: $darkest-gray;
+$toast-border-radius: $font-size-base * 0.5;
+$toast-color: $white;
 
 $toast-padding-x: 1.15rem;
 $toast-padding-y: 0.5rem;

--- a/src/vuestic-theme/vuestic-sass/resources/_variables.scss
+++ b/src/vuestic-theme/vuestic-sass/resources/_variables.scss
@@ -29,10 +29,8 @@ $brand-success: $vue-green;
 $light-gray2: #eff4f5;
 $dark-gray: #282828;
 $gray: #adb3b9;
-$violet: #db76df;
 $dark-blue: #0045b6;
 $text-gray: #b4b4b4;
-$on-focus-background-color: rgba(187, 180, 178, 0.71);
 
 $colors-map: (
   brand-danger: $brand-danger,
@@ -64,6 +62,7 @@ $layout-padding: 24px;
 $layout-padding-right: 44px;
 
 $top-nav-height: 72px;
+
 $nav-padding-left: $layout-padding;
 $nav-padding-right: $layout-padding-right;
 $navbar-brand-container-left: 75px;
@@ -72,14 +71,13 @@ $sidebar-bg: $darkest-gray;
 $sidebar-width: 225px;
 $sidebar-top: calc(#{$top-nav-height} + #{$layout-padding});
 $sidebar-left: $layout-padding;
+$min-z-index: -1000;
 
 $content-wrap-ml: calc(#{$sidebar-left} + #{$sidebar-width} + 35px);
 $content-wrap-pb: $layout-padding;
 $made-by-footer-pb: 27px;
 
 $greeny-box-shadow: 0 4px 9.6px 0.4px rgba($vue-green, .5);
-
-$min-z-index: -1000;
 
 //Auth
 $auth-wallpaper-ivuestic-h: 2.625rem;
@@ -93,29 +91,18 @@ $checkbox-label-margin-top: 0.2rem;
 //Mobile Layout
 $top-mobile-nav-height: 6.5rem;
 $layout-mobile-padding: 0.1875rem;
-$layout-mobile-padding-right: .375rem;
 
-$sidebar-mobile-width: calc(100% - #{$layout-mobile-padding-right});
+$sidebar-mobile-width: calc(100% - .375rem);
 $sidebar-mobile-top: $top-mobile-nav-height+$layout-mobile-padding;
 $sidebar-mobile-left: $layout-mobile-padding;
 $sidebar-mobile-z-index: 1000;
 
 $content-mobile-wrap-pl: 1rem;
 $content-mobile-wrap-pr: 1rem;
-$content-mobile-wrap-pt: 2rem;
 $content-mobile-wrap-pb: $layout-padding;
-$content-mobile-wrap: $content-mobile-wrap-pt $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
+$content-mobile-wrap: 2rem $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
 $content-mobile-wrap-fixed-layout: 7rem $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
 $content-mobile-wrap-sb-top: calc(#{$top-nav-height} + #{$layout-padding+20}) - 20 px;
-
-$nav-mobile-padding-h: .875rem;
-$nav-mobile-pt: 1.75rem;
-$nav-mobile-pb: 0.5rem;
-$nav-mobile-brand-width: 4rem;
-$nav-mobile-brand-top: .875rem;
-$nav-mobile-brand-left: calc(50% - #{$nav-mobile-brand-width});
-
-$dropdown-mobile-show-b: 2rem;
 
 //Auth mobile
 $auth-mobile-nav-ivuestic-h: 1.5rem;
@@ -127,8 +114,6 @@ $auth-content-padding-t: 2.875rem;
 
 //$text-color:            $gray !default;
 
-$font-family-sans-serif: 'Source Sans Pro', sans-serif !default;
-
 $font-size-root: 16px;
 
 $font-size-base: 1rem !default;
@@ -137,32 +122,14 @@ $font-size-large: 1.5rem;
 $font-size-mini: 0.8rem;
 
 $font-weight-bold: 700 !default;
-$font-weight-semi-bold: 600 !default;
-$font-weight-normal: 400 !default;
-$font-weight-thin: 300 !default;
-$font-weight-base: $font-weight-thin !default;
 
 $font-size-smaller: 85% !default;
 
-$font-size-h1: 2.625rem !default;
-$font-size-h2: 2.25rem !default;
-$font-size-h3: 1.75rem !default;
 $font-size-h4: 1.375rem !default;
-
-$headings-line-height: 1 !default;
 
 $blockquote-border-color: $vue-green;
 $blockquote-small-color: $gray-light;
 $blockquote-border-width: 0.375rem;
-$blockquote-font-size: 1.5rem;
-
-//Navbar
-$navbar-dd-item-height: 48px;
-
-//Breadcrumbs
-$breadcrumbs-height: 54px;
-$breadcrumbs-arrow-font: 0.7rem;
-$breadcrumbs-arrow-content: "\f054";
 
 //Sidebar
 $sidebar-link-height: 64px;
@@ -181,18 +148,16 @@ $sidebar-box-shadow: 0px 8px 14.72px 1.28px rgba(#65a977, 0.3);
 
 //Widgets
 $widget-bg: $white;
-$widget-padding: 1.5625rem;
 $widget-larger-padding: 45px;
-$widget-box-shadow: 0px 4px 70px -18px #707070;
 $widget-danger-shadow: 0px 4px 70px -16px $brand-danger;
 $widget-info-shadow: 0px 4px 70px -16px $brand-info;
-$widget-viewport-height: $sidebar-viewport-height;
+$info-widget-border: 0.5rem solid $brand-primary;
+
+$widget-padding: 1.5625rem;
+$widget-box-shadow: 0px 4px 70px -18px #707070;
 $widget-header-border: 2px solid $light-gray;
 $widget-header-height: 55px;
-$widget-body-no-header-height: 100%;
-$widget-body-with-header-height: calc(100% - #{$widget-header-height});
 $widget-mb: 1.875rem;
-$info-widget-border: 0.5rem solid $brand-primary;
 
 //Buttons
 $btn-line-height: 1.25;
@@ -234,11 +199,6 @@ $dropdown-menu-padding-y: 10px;
 $dropdown-menu-padding-x: 0;
 $dropdown-show-b: 1.125rem;
 
-//Forms
-$vuestic-switch-bg: $brand-primary;
-$vuestic-switch-padding: 0.313rem 2.375rem;
-$vuestic-switch-border-size: 0.125rem;
-
 //Progress Bars
 $progress-bar-value-font-size: 0.6875rem;
 $progress-bar-circle-diameter: 3.125rem;
@@ -254,7 +214,6 @@ $vertical-progress-bar-width-thick: 2rem;
 $table-border-color: #eceeef;
 $striped-row-odd: $white;
 $striped-row: $light-gray2;
-$state-info-bg: #dcf1ff;
 $table-hover-bg: rgba($vue-green, .5);
 
 //Badges
@@ -288,10 +247,6 @@ $alert-danger-shadow: 0px 4px 9.6px 0.4px rgba(206, 79, 79, 0.5);
 
 $tab-content-pt: 3.125rem;
 $tab-content-pb: 1.5rem;
-
-//PreLoader
-$vuestic-preloader-left: calc(50% - 140px / 2);
-$vuestic-preloader-top: calc(50% - 104px / 2);
 
 //Medium Editor
 $medium-editor-button-size: $btn-padding-y * 2 + $font-size-base * $btn-line-height;

--- a/src/vuestic-theme/vuestic-sass/resources/_variables.scss
+++ b/src/vuestic-theme/vuestic-sass/resources/_variables.scss
@@ -56,6 +56,7 @@ $theme-colors: (
 );
 
 // Layout //
+$body-bg: $light-gray;
 $top-nav-bg: $darkest-gray;
 $body-color: $vue-darkest-blue !default;
 $layout-padding: 24px;
@@ -113,7 +114,7 @@ $auth-content-padding-t: 2.875rem;
 // -------------------------
 
 //$text-color:            $gray !default;
-
+$font-family-sans-serif: 'Source Sans Pro', sans-serif !default;
 $font-size-root: 16px;
 
 $font-size-base: 1rem !default;
@@ -122,14 +123,24 @@ $font-size-large: 1.5rem;
 $font-size-mini: 0.8rem;
 
 $font-weight-bold: 700 !default;
+$font-weight-semi-bold: 600 !default;
+$font-weight-normal: 400 !default;
+$font-weight-thin: 300 !default;
+$font-weight-base: $font-weight-thin !default;
 
 $font-size-smaller: 85% !default;
 
+$font-size-h1: 2.625rem !default;
+$font-size-h2: 2.25rem !default;
+$font-size-h3: 1.75rem !default;
 $font-size-h4: 1.375rem !default;
+
+$headings-line-height: 1 !default;
 
 $blockquote-border-color: $vue-green;
 $blockquote-small-color: $gray-light;
 $blockquote-border-width: 0.375rem;
+$blockquote-font-size: 1.5rem;
 
 //Sidebar
 $sidebar-link-height: 64px;
@@ -222,6 +233,8 @@ $badge-success-bg: $brand-success;
 
 //Alerts
 $with-close-pr: 3.125rem;
+$alert-padding-x: 1.25rem !default;
+$alert-padding-y: .75rem !default;
 
 $alert-success-bg: $light-green;
 $alert-success-text: $body-color;


### PR DESCRIPTION
refactor #365 

list of vars, which have been changed

removed
$violet: #db76df;
$on-focus-background-color: rgba(187, 180, 178, 0.71);

// Layout //
removed
$content-wrap-pr: $layout-padding-right; 
$content-wrap-pt: $layout-padding; 

//Mobile Layout
removed
$layout-mobile-padding-right: .375rem; 
$content-mobile-wrap-margin: 1.125rem; 
$content-mobile-wrap-pt: 2rem; 
$content-mobile-wrap-pt-fixed-layout: 7rem; 

move to ./vuestic-theme/vuestic-components/vuestic-navbar/VuesticNavbar.vue
$nav-mobile-padding-h: .875rem;
$nav-mobile-pt: 1.75rem;
$nav-mobile-pb: 0.5rem;
$nav-mobile-brand-width: 4rem;
$nav-mobile-brand-top: .875rem;
$nav-mobile-brand-left: calc(50% - #{$nav-mobile-brand-width});
$droppdown-mobile-mp: 1.9375rem; removed
$dropdown-mobile-show-b: 2rem;

//Navbar
moved to vuestic-theme/vuestic-components/vuestic-navbar/VuesticNavbar.vue
$navbar-dd-item-height: 48px;

//Breadcrumbs
vuestic-theme/vuestic-components/vuestic-breadcrumbs/VuesticBreadcrumbs.vue
$breadcrumbs-height: 54px;
$breadcrumbs-arrow-font: 0.7rem;
$breadcrumbs-arrow-content: "\f054";

//Sidebar
$sidebar-box-shadow: 0px 8px 14.72px 1.28px rgba(#65a977, 0.3); strange color not in vars list


//Widgets
$widget-box-shadow: 0px 4px 70px -18px rgba(112, 112, 112, 1); not hex color. changed to hex but WITHOUT VAR
removed
$widget-viewport-height: $sidebar-viewport-height; 
$widget-body-no-header-height: 100%; 
$widget-body-with-header-height: calc(100% - #{$widget-header-height}); 

//Buttons
removed
$input-btn-border-width: 0px; 
$btn-dark-color: $white; 
$btn-dark-bg: $darkest-gray; 
$btn-dark-border: $darkest-gray; 
$btn-pale-bg: $theme-pale; 
$btn-pale-color: $white; 

//Dropdowns
removed
$dropdown-link-color: $white; 
$dropdown-link-color: $white; 
$dropdown-link-hover-color: $white; 
$dropdown-link-hover-bg: $almost-black; 
$dropdown-link-active-color: $white; 
$dropdown-link-active-bg: $almost-black; 
$dropdown-item-padding-x: 25px; 
$dropdown-item-padding-y: 0; 
$dropdown-min-width: 15rem; 
$dropdown-simple-visible-items: 4; 
$dropdown-multi-visible-items: 4; 

not move left items because them used in several times in bootstrap-override and nav bar

//Modals
removed
$modal-content-border-width: 0; 
$modal-md: 650px; 
$modal-lg: 850px;

duplicate vars from dublicate /vuestic-theme/vuestic-components/vuestic-modal/VuesticModal.vue. removed from here.
$modal-header-padding-x: $widget-padding;
$modal-header-padding-y: 0;
$modal-header-height: $widget-header-height;
$modal-header-border: $widget-header-border;
$modal-content-border-radius: 0;
$modal-inner-padding: 25px;
$modal-footer-btns-padding-bottom: 20px;
$modal-footer-btns-margin-x: 10px;

//Forms
removed
$input-border-color: $lighter-gray; 
$input-bg-disabled: $white; 

moved to vuestic-theme/vuestic-components/vuestic-switch/VuesticSwitch.vue
$vuestic-switch-bg: $brand-primary;
$vuestic-switch-padding: 0.313rem 2.375rem;
$vuestic-switch-border-size: 0.125rem;

//Tables
removed
$table-bg-accent: $white; 
$table-border-width: 0; 
$state-success-bg: #c8fac6; 
$state-danger-bg: #ffcece; 
$state-warning-bg: #fff1c8; 
$state-info-bg: #dcf1ff; 
$table-active-bg: $table-hover-bg; 

//Badges
removed
$badge-padding-y: 0.28rem; 
$badge-font-size: 0.7rem; 
$badge-warning-bg: $theme-orange; 
$badge-danger-bg: $theme-red; 
$badge-info-bg: $theme-blue; 

//Alerts
removed
$alert-padding-x: 1.25rem !default; 
$alert-padding-y: .75rem !default; 
$alert-margin-bottom: $widget-mb; 
$alert-border-radius: 0; 
$alert-border-width: 0; 

moved to ./vuestic-theme/vuestic-sass/icons/_fonts.scss
//Icons
$bootstrap-sass-asset-helper: false;
$icon-font-name: 'glyphicons-halflings-regular';
$icon-font-svg-id: 'glyphicons_halflingsregular';
$icon-font-path: './fonts/';

//PreLoader
moved to vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
$vuestic-preloader-left: calc(50% - 140px / 2);
$vuestic-preloader-top: calc(50% - 104px / 2);

//tooltips
removed
$tooltip-font-size: $font-size-base; 
$tooltip-max-width: 200px; 
$tooltip-color: $white; 
$tooltip-bg: $darkest-gray; 
$tooltip-border-radius: $font-size-base * 0.5; 
$tooltip-opacity: .9; 
$tooltip-padding-y: .5rem; 
$tooltip-padding-x: .75rem; 
$tooltip-margin: 0; 
$tooltip-arrow-width: .8rem; 
$tooltip-arrow-height: .4rem; 
$tooltip-arrow-color: $tooltip-bg; 

// Popovers
removed
$popover-font-size: $font-size-base; 
$popover-bg: $tooltip-bg; 
$popover-max-width: 400px; 
$popover-border-width: 0; 
$popover-border-color: transparent; 
$popover-border-radius: $tooltip-border-radius; 
$popover-opacity: $tooltip-opacity; 
$popover-header-bg: $tooltip-bg;  
$popover-header-color: $white;  
$popover-header-padding-y: 0;  
$popover-header-padding-x: .75rem;  
$popover-header-no-icon-padding-x: 0;  
$popover-header-font-weight: bold;  
$popover-body-color: $white;  
$popover-body-padding-x: $popover-header-padding-x; 
$popover-body-no-icon-padding-x: $popover-header-no-icon-padding-x; 

$popover-arrow-width: 1rem;  
$popover-arrow-height: 1rem; 
$popover-arrow-color: transparent; 
$popover-arrow-outer-color: fade-in($popover-border-color, .05); 

// Toasts
removed
$toast-color: $popover-body-color; 
$toast-opacity: $popover-opacity; 

$toast-bg: $popover-bg; changed to color because popover bg use only here
$toast-border-radius: $popover-border-radius; changed to value because popover border radius used only here