### PR TITLE
refactor(core): remove useless scss selector

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Hi! We are really excited that you are interested in contributing to Vuestic. Before submitting your contribution though, please make sure to take a moment and read through the following guidelines.
 
-* [Code of Conduct](https://github.com/epicmaxco/vuestic-admin/master/CODE_OF_CONDUCT.md)
+* [Code of Conduct](./../CODE_OF_CONDUCT.md)
 
 ## Pull Request Guidelines
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,9 +20,8 @@ Commit messages should follow the [commit message convention](./COMMIT_CONVENTIO
 ### Branches
 
 * Public branches (**epicmax/vuestic-admin**):
-  * `master` - stable snapshot from `develop`. Releases and hotfixes only. Do not submit PR's to `master`!
-  * `develop` - main development branch. Houses `1.9` at the moment.
-  * `2.0-release` - secondary development branch. Sits on top of `develop` (feel free to merge if something is missing).
+  * `master` - stable snapshot from `develop`. Releases and hotfixes only. Do not submit PR's to `master`! (that's not entirely true as hotfixes are still possible to be in master, but not in develop).
+  * `develop` - main development branch. Houses `2.0` at the moment.
 
 * Local branches
   * For local branches naming stick to [commit message convention](./COMMIT_CONVENTION.md). So for feature branch that adds tabs name would be `feat/tabs`.

--- a/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
@@ -15,10 +15,8 @@
 
 <script>
 import Resize from '../../../directives/ResizeHandler'
-
 export default {
   name: 'vuestic-layout',
-
   props: {
     fixed: {
       type: Boolean,
@@ -40,30 +38,15 @@ export default {
 
 <style lang="scss">
 .vuestic-layout {
-  &-fixed {
-    .content-wrap {
-      padding-right: $layout-padding-right;
-      padding-top: $sidebar-top;
-
-      @include media-breakpoint-down(md) {
-        padding: $content-mobile-wrap-fixed-layout;
-        margin-left: 0;
-
-      }
-    }
-  }
-
   .content-wrap {
     margin-left: $content-wrap-ml;
     transition: margin-left 0.3s ease;
     padding: $layout-padding $layout-padding-right $content-wrap-pb 0;
-
     .pre-loader {
       position: absolute;
       left: $vuestic-preloader-left;
       top: $vuestic-preloader-top;
     }
-
     @include media-breakpoint-down(md) {
       padding: $content-mobile-wrap;
       margin-left: 0;
@@ -73,6 +56,17 @@ export default {
       }
     }
   }
+  &-fixed {
+    .content-wrap {
+      padding-right: $layout-padding-right;
+      padding-top: $sidebar-top;
+      @include media-breakpoint-down(md) {
+        padding: $content-mobile-wrap-fixed-layout;
+        margin-left: 0;
+      }
+    }
+  }
+  
   .made-by-footer {
     display: flex;
     justify-content: center;

--- a/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-layout/VuesticLayout.vue
@@ -1,8 +1,5 @@
 <template>
-  <div class="vuestic-layout"
-       v-resize
-       :class="classObject"
-  >
+  <div class="vuestic-layout" v-resize :class="classObject">
     <slot></slot>
     <div class="content-wrap" id="content-wrap">
       <slot name="content"></slot>
@@ -14,26 +11,26 @@
 </template>
 
 <script>
-import Resize from '../../../directives/ResizeHandler'
+import Resize from "../../../directives/ResizeHandler";
 export default {
-  name: 'vuestic-layout',
+  name: "vuestic-layout",
   props: {
     fixed: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   directives: {
-    resize: Resize,
+    resize: Resize
   },
   computed: {
-    classObject: function () {
+    classObject: function() {
       return {
-        'layout-fixed': this.fixed,
-      }
-    },
-  },
-}
+        "layout-fixed": this.fixed
+      };
+    }
+  }
+};
 </script>
 
 <style lang="scss">
@@ -50,10 +47,6 @@ export default {
     @include media-breakpoint-down(md) {
       padding: $content-mobile-wrap;
       margin-left: 0;
-      .sidebar-hidden & {
-        margin-left: 0;
-        padding-top: $content-mobile-wrap-sb-top;
-      }
     }
   }
   &-fixed {
@@ -66,7 +59,7 @@ export default {
       }
     }
   }
-  
+
   .made-by-footer {
     display: flex;
     justify-content: center;

--- a/src/vuestic-theme/vuestic-sass/resources/_variables.scss
+++ b/src/vuestic-theme/vuestic-sass/resources/_variables.scss
@@ -111,7 +111,6 @@ $content-mobile-wrap-pt-fixed-layout: 7rem;
 $content-mobile-wrap-pb: $layout-padding;
 $content-mobile-wrap: $content-mobile-wrap-pt $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
 $content-mobile-wrap-fixed-layout: $content-mobile-wrap-pt-fixed-layout $content-mobile-wrap-pr $content-mobile-wrap-pb $content-mobile-wrap-pl;
-$content-mobile-wrap-sb-top: calc(#{$top-nav-height} + #{$layout-padding+20}) - 20 px;
 
 $nav-mobile-padding-h: .875rem;
 $nav-mobile-pt: 1.75rem;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Remove a wrong scss selector which is impossible to reach.

## Markup:
<!-- Paste your markup here. -->
<details>

```scss
.vuestic-layout {
  .content-wrap {
    margin-left: $content-wrap-ml;
    transition: margin-left 0.3s ease;
    padding: $layout-padding $layout-padding-right $content-wrap-pb 0;
    .pre-loader {
      position: absolute;
      left: $vuestic-preloader-left;
      top: $vuestic-preloader-top;
    }
    @include media-breakpoint-down(md) {
      padding: $content-mobile-wrap;
      margin-left: 0;
      .sidebar-hidden & {
        margin-left: 0;
        padding-top: $content-mobile-wrap-sb-top;
      }
    }
  }
}
```

```scss
    .sidebar-hidden & {
        margin-left: 0;
        padding-top: $content-mobile-wrap-sb-top;
      }
```
has to be removed because it will generate
```css
.sidebar-hidden .vuestic-layout .content-wrap {}
```
which is impossible to reach because `.vuestic-layout` is not a descendant of `.sidebar-hidden`
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
