### PR TITLE
Scrollbar component: fixed low speed scrolling on Firefox

### DIFF
--- a/src/vuestic-theme/vuestic-components/vuestic-scrollbar/VuesticScrollbar.vue
+++ b/src/vuestic-theme/vuestic-components/vuestic-scrollbar/VuesticScrollbar.vue
@@ -18,7 +18,8 @@
 </template>
 
 <script>
-const browser = require('detect-browser')
+const { detect } = require('detect-browser')
+const browser = detect()
 const erd = require('element-resize-detector')()
 
 export default {


### PR DESCRIPTION
## Description
Fixed low scrolling speed on scrollbar component on Firefox.  The _detect_browser_ package wasn't correctly called so it was unable to detect Firefox and apply the correct scroll delta. 

```vue
const { detect } = require('detect-browser')
const browser = detect()
```
</details>

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
