### PR TITLE
Fixed minimizedWidth prop type in Sidebar

### DIFF
--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -27,7 +27,7 @@ export default {
     color: { type: String, default: "secondary" },
     minimized: { type: Boolean, required: true },
     minimizedWidth: {
-      type: Boolean,
+      type: String,
       required: false,
       default: undefined
     },


### PR DESCRIPTION
<!--
MAKE SURE TO READ THE CONTRIBUTING GUIDE BEFORE CREATING A PR
https://github.com/epicmaxco/vuestic-admin/blob/master/CODE_OF_CONDUCT.md
-->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Keep the title short and descriptive, as it will be used as a commit message -->

## Description
<!-- Describe your changes in detail -->
I was getting a warning in the browser console about an invalid value being passed to the "minimizedWidth" prop. Looking at the source and at [Vuestic UI sidebar docs](https://vuestic.dev/en/ui-elements/sidebar), seems like such prop in the Sidebar component should be typed "String" rather than "Boolean". In my codebase (started from scratch and picking parts from here) this change seems to fix the warning.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
