### PR TITLE
fix: sidebar expansion impacts layout

### DIFF
--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -14,8 +14,16 @@
 
     <template #content>
       <div :class="{ minimized: isSidebarMinimized }" class="app-layout__sidebar-wrapper">
-        <div v-if="isFullScreenSidebar" class="flex justify-end">
-          <VaButton class="px-4 py-4" icon="md_close" preset="plain" @click="onCloseSidebarButtonClick" />
+        <div v-if="isFullScreenSidebar" class="flex justify-end h-0">
+          <VaButton
+            class="px-4 py-4"
+            icon="md_close"
+            preset="plain"
+            text-opacity="0"
+            @click="onCloseSidebarButtonClick"
+          >
+            Close Sidebar
+          </VaButton>
         </div>
       </div>
       <AppLayoutNavigation v-if="!isMobile" class="p-4" />


### PR DESCRIPTION
## Description

Improved sidebar close button accessibility by adding text label and adjusting styles to fix  layout issue where main content was pushed down when the sidebar was expanded in the tablet breakpoint. Ensuring button remains in the DOM for A11y purposes, but has no effective height that impacts layout .

Before this PR:
![before](https://github.com/user-attachments/assets/e8c33390-2437-43a6-9c45-dc8c595192e4)

Changes in this PR:
![after](https://github.com/user-attachments/assets/76f3f112-0e3a-448e-ab91-e471da91c925)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
